### PR TITLE
Refine prompts with clearer instructions

### DIFF
--- a/chatgpt-tools.js
+++ b/chatgpt-tools.js
@@ -25,7 +25,10 @@ async function callOpenAI(prompt) {
   const response = await openai.createChatCompletion({
     model: 'gpt-4',
     messages: [
-      { role: 'system', content: 'You are an educational assistant generating documents for schools.' },
+      {
+        role: 'system',
+        content: `You are an educational assistant generating documents for schools. Use a professional but friendly tone and format responses with headings or bullet points. Keep answers under 800 words, follow safeguarding guidance, use inclusive language and only reference details provided. Do not provide legal or medical advice.`
+      },
       { role: 'user', content: prompt }
     ],
     max_tokens: 800,
@@ -44,7 +47,7 @@ export const toolDefinitions = {
   behaviourSupportPlan: {
     prompt: (data) => {
       const { studentName, concerns } = data;
-      return `Generate a behaviour support plan for a pupil.\n\nPupil name: ${studentName}\nBehaviour concerns: ${concerns.join(', ')}\n\nThe plan should outline positive strategies, interventions and monitoring procedures in a friendly and supportive tone.`;
+      return `Generate a behaviour support plan for a pupil.\n\nPupil name: ${studentName}\nBehaviour concerns: ${concerns.join(', ')}\n\nUse sections for Positive Strategies, Interventions and Monitoring. Keep the tone friendly and supportive.`;
     },
     form: [
       { name: 'studentName', label: 'Student Name', type: 'text', required: true },
@@ -54,7 +57,7 @@ export const toolDefinitions = {
   attendanceImprovementPlan: {
     prompt: (data) => {
       const { cohort, currentAttendance, targetAttendance } = data;
-      return `Create an attendance improvement plan for ${cohort}. Current attendance: ${currentAttendance}%. Target attendance: ${targetAttendance}%. Outline steps to engage families, incentives, monitoring and support.`;
+      return `Create an attendance improvement plan for ${cohort}. Current attendance: ${currentAttendance}%. Target attendance: ${targetAttendance}%.\n\nInclude engagement strategies for families, incentives and a monitoring timeline.`;
     },
     form: [
       { name: 'cohort', label: 'Cohort (e.g. Year Group or Student)', type: 'text', required: true },
@@ -65,7 +68,7 @@ export const toolDefinitions = {
   lessonPlan: {
     prompt: (data) => {
       const { subject, yearGroup, objectives, duration } = data;
-      return `Design a detailed lesson plan for ${subject} (${yearGroup}). Learning objectives: ${objectives.join('; ')}. Duration: ${duration} minutes. Include a starter, main activity, differentiation and plenary.`;
+      return `Design a detailed lesson plan for ${subject} (${yearGroup}). Learning objectives: ${objectives.join('; ')}. Duration: ${duration} minutes.\n\nUse headings for Starter, Main Activity, Differentiation and Plenary.`;
     },
     form: [
       { name: 'subject', label: 'Subject', type: 'text', required: true },
@@ -77,7 +80,7 @@ export const toolDefinitions = {
   worksheet: {
     prompt: (data) => {
       const { topic, questionCount, difficulty } = data;
-      return `Generate a worksheet for the topic "${topic}" with ${questionCount} questions. Difficulty: ${difficulty}. Provide clear questions and leave space for answers.`;
+      return `Generate a worksheet for the topic "${topic}" with ${questionCount} questions. Difficulty: ${difficulty}.\n\nProvide clear questions and leave space for answers.`;
     },
     form: [
       { name: 'topic', label: 'Topic', type: 'text', required: true },
@@ -88,7 +91,7 @@ export const toolDefinitions = {
   scienceInvestigation: {
     prompt: (data) => {
       const { concept, ageGroup } = data;
-      return `Outline a science investigation for the concept of ${concept} suitable for ${ageGroup}. Include hypothesis, variables, materials, method, safety and expected outcomes.`;
+      return `Outline a science investigation for the concept of ${concept} suitable for ${ageGroup}.\n\nInclude sections for Hypothesis, Variables, Materials, Method, Safety and Expected Outcomes.`;
     },
     form: [
       { name: 'concept', label: 'Scientific Concept', type: 'text', required: true },

--- a/educational-ai-platform/backend/api/all-tools.js
+++ b/educational-ai-platform/backend/api/all-tools.js
@@ -23,7 +23,10 @@ async function callChatGPT(prompt) {
     body: JSON.stringify({
       model: 'gpt-4',
       messages: [
-        { role: 'system', content: 'You are an educational assistant generating documents for schools.' },
+        {
+          role: 'system',
+          content: `You are an educational assistant generating documents for schools. Use a friendly yet professional tone and format outputs with clear headings or bullet points. Keep responses under 800 words. Follow safeguarding and data privacy best practices, only using details provided. Do not offer legal or medical advice.`
+        },
         { role: 'user', content: prompt }
       ],
       max_tokens: 800,
@@ -54,130 +57,130 @@ function buildResponse(title, body) {
 
 // Leadership and management tools
 export const generateBehaviourSupportPlan = async ({ studentName, concerns }) => {
-  const prompt = `Create a behaviour support plan for a pupil named ${studentName}. Concerns: ${concerns.join(', ')}. Include positive strategies, interventions and monitoring steps.`;
+  const prompt = `Create a behaviour support plan for pupil ${studentName}. Concerns: ${concerns.join(', ')}.\n\nFormat using the sections:\n- Positive Strategies\n- Interventions\n- Monitoring\n\nUse bullet points and a supportive tone for teachers and families.`;
   const body = await callChatGPT(prompt);
   return buildResponse('Behaviour Support Plan', body);
 };
 
 export const createAttendanceImprovementPlan = async ({ cohort, targets }) => {
-  const prompt = `Write an attendance improvement plan for ${cohort}. Target attendance: ${targets.targetPercentage}%. Suggest engagement strategies and rewards.`;
+  const prompt = `Write an attendance improvement plan for ${cohort}. Target attendance: ${targets.targetPercentage}%.\n\nInclude:\n- Engagement strategies for families\n- Incentives and rewards\n- Monitoring timeline.\nUse a clear, professional style.`;
   const body = await callChatGPT(prompt);
   return buildResponse('Attendance Improvement Plan', body);
 };
 
 export const generateAccessibilityStrategy = async ({ schoolContext }) => {
-  const prompt = `Draft an accessibility strategy for ${schoolContext.name}. Outline adjustments to ensure equal access for all pupils including physical adaptations and staff training.`;
+  const prompt = `Draft an accessibility strategy for ${schoolContext.name}.\n\nProvide bullet points on physical adaptations, staff training and communication adjustments to ensure equal access for all pupils.`;
   const body = await callChatGPT(prompt);
   return buildResponse('Accessibility Strategy', body);
 };
 
 export const generateStrategicPlan = async ({ years, objectives }) => {
-  const prompt = `Generate a ${years}-year strategic plan focusing on: ${objectives.join('; ')}. Provide key actions, timelines and success criteria.`;
+  const prompt = `Generate a ${years}-year strategic plan focusing on: ${objectives.join('; ')}.\n\nStructure with yearly milestones, key actions and success criteria in bullet points.`;
   const body = await callChatGPT(prompt);
   return buildResponse(`${years}-Year Strategic Plan`, body);
 };
 
 export const generateRiskAssessmentReport = async ({ activity, hazards }) => {
-  const prompt = `Create a risk assessment for ${activity}. Hazards: ${hazards.join(', ')}. Include mitigation measures and residual risk evaluation.`;
+  const prompt = `Create a risk assessment for ${activity}. Hazards: ${hazards.join(', ')}.\n\nList mitigation measures and evaluate residual risk under clear headings.`;
   const body = await callChatGPT(prompt);
   return buildResponse('Risk Assessment Report', body);
 };
 
 export const createMeetingAgenda = async ({ meetingType, items }) => {
   const agendaItems = items.map((item, idx) => `${idx + 1}. ${item}`).join('\n');
-  const prompt = `Write a meeting agenda for a ${meetingType} meeting with the following items:\n${agendaItems}`;
+  const prompt = `Write a meeting agenda for a ${meetingType} meeting with the following items:\n${agendaItems}\n\nUse a numbered list and include expected timings if known.`;
   const body = await callChatGPT(prompt);
   return buildResponse('Meeting Agenda', body);
 };
 
 export const createNewsletter = async ({ audience, highlights }) => {
-  const prompt = `Draft a short newsletter for ${audience} highlighting: ${highlights.join(', ')}.`;
+  const prompt = `Draft a short newsletter for ${audience} highlighting: ${highlights.join(', ')}.\n\nOpen with a friendly greeting and keep paragraphs brief.`;
   const body = await callChatGPT(prompt);
   return buildResponse('School Newsletter', body);
 };
 
 export const generatePolicy = async ({ policyName, principles }) => {
-  const prompt = `Write a ${policyName} policy. Guiding principles: ${principles.join(', ')}. Include key procedures and review cycles.`;
+  const prompt = `Write a ${policyName} policy. Guiding principles: ${principles.join(', ')}.\n\nInclude key procedures, responsibilities and review cycles using headings.`;
   const body = await callChatGPT(prompt);
   return buildResponse(`${policyName} Policy`, body);
 };
 
 export const generateGovernorProfile = async ({ governorName, background }) => {
-  const prompt = `Create a short profile for school governor ${governorName} highlighting their background in ${background}.`;
+  const prompt = `Create a short profile for school governor ${governorName} highlighting their background in ${background}.\nUse no more than two short paragraphs.`;
   const body = await callChatGPT(prompt);
   return buildResponse('Governor Profile', body);
 };
 
 export const generateHeadteacherReport = async ({ term, achievements }) => {
-  const prompt = `Write a headteacher report for the ${term} term highlighting achievements: ${achievements.join(', ')}. Include upcoming priorities and challenges.`;
+  const prompt = `Write a headteacher report for the ${term} term.\n\nSections:\n- Achievements (${achievements.join(', ')})\n- Upcoming priorities\n- Key challenges.\nKeep the tone professional.`;
   const body = await callChatGPT(prompt);
   return buildResponse('Headteacher Report', body);
 };
 
 // Teaching and learning tools
 export const createLessonPlan = async ({ subject, yearGroup, objectives, duration }) => {
-  const prompt = `Create a ${duration} minute lesson plan for ${subject} (${yearGroup}). Objectives: ${objectives.join(', ')}. Include starter, main activity, differentiation and plenary.`;
+  const prompt = `Create a ${duration} minute lesson plan for ${subject} (${yearGroup}). Objectives: ${objectives.join(', ')}.\n\nUse headings for Starter, Main Activity, Differentiation and Plenary.`;
   const body = await callChatGPT(prompt);
   return buildResponse('Lesson Plan', body);
 };
 
 export const createMediumTermPlan = async ({ subject, term, topics }) => {
-  const prompt = `Generate a medium term plan for ${subject} during ${term}. Cover topics: ${topics.join(', ')} with weekly learning goals and assessments.`;
+  const prompt = `Generate a medium term plan for ${subject} during ${term}.\n\nList weekly topics (${topics.join(', ')}) with learning goals and suggested assessments.`;
   const body = await callChatGPT(prompt);
   return buildResponse('Medium Term Plan', body);
 };
 
 export const generateAssemblyOutline = async ({ theme, ageGroup, keyMessages }) => {
-  const prompt = `Create an assembly outline on the theme of ${theme} for ${ageGroup} pupils. Key messages: ${keyMessages.join(', ')}. Include introduction, main story and conclusion.`;
+  const prompt = `Create an assembly outline on the theme of ${theme} for ${ageGroup} pupils.\n\nInclude Introduction, Main Story and Conclusion sections highlighting: ${keyMessages.join(', ')}.`;
   const body = await callChatGPT(prompt);
   return buildResponse('Assembly Outline', body);
 };
 
 export const generateWorksheet = async ({ topic, questions }) => {
   const questionList = questions.map((q, idx) => `${idx + 1}. ${q}`).join('\n');
-  const prompt = `Produce a worksheet on ${topic} with the following questions:\n${questionList}`;
+  const prompt = `Produce a worksheet on ${topic}.\n\nProvide a short introduction and list the questions:\n${questionList}\n\nLeave space for answers.`;
   const body = await callChatGPT(prompt);
   return buildResponse('Worksheet', body);
 };
 
 export const generateQuiz = async ({ subject, quizQuestions }) => {
-  const prompt = `Create a quiz for ${subject} with questions: ${quizQuestions.join(' | ')}.`;
+  const prompt = `Create a quiz for ${subject} with the following questions: ${quizQuestions.join(' | ')}.\nList each question with multiple choice options labelled A-D.`;
   const body = await callChatGPT(prompt);
   return buildResponse('Quiz', body);
 };
 
 export const generateKnowledgeOrganiser = async ({ topic, facts }) => {
-  const prompt = `Write a knowledge organiser for ${topic} including facts: ${facts.join(', ')}.`;
+  const prompt = `Write a knowledge organiser for ${topic}.\n\nInclude key facts in bullet points: ${facts.join(', ')}.`;
   const body = await callChatGPT(prompt);
   return buildResponse('Knowledge Organiser', body);
 };
 
 export const createRubric = async ({ assignment, criteria }) => {
-  const prompt = `Create an assessment rubric for ${assignment}. Criteria: ${criteria.join(', ')}. Include descriptors for achievement levels.`;
+  const prompt = `Create an assessment rubric for ${assignment}.\nCriteria: ${criteria.join(', ')}.\nProvide descriptors for each achievement level in a table.`;
   const body = await callChatGPT(prompt);
   return buildResponse('Assessment Rubric', body);
 };
 
 export const generateExitTicket = async ({ lesson, reflectionQuestions }) => {
-  const prompt = `Generate an exit ticket for a lesson on ${lesson}. Include reflection questions: ${reflectionQuestions.join('; ')}.`;
+  const prompt = `Generate an exit ticket for a lesson on ${lesson}.\n\nList a few short reflection questions: ${reflectionQuestions.join('; ')}.`;
   const body = await callChatGPT(prompt);
   return buildResponse('Exit Ticket', body);
 };
 
 export const generateMathsProblems = async ({ topic, difficulty, count }) => {
-  const prompt = `Create ${count} ${difficulty} maths problems on the topic of ${topic}. Include space for working and answers.`;
+  const prompt = `Create ${count} ${difficulty} maths problems on the topic of ${topic}.\nNumber each problem and leave space for working and answers.`;
   const body = await callChatGPT(prompt);
   return buildResponse('Maths Problems', body);
 };
 
 export const createScienceInvestigation = async ({ concept, ageGroup }) => {
-  const prompt = `Outline a science investigation exploring ${concept} suitable for ${ageGroup}. Include hypothesis, materials, method and safety.`;
+  const prompt = `Outline a science investigation exploring ${concept} suitable for ${ageGroup}.\n\nInclude sections for Hypothesis, Materials, Method and Safety.`;
   const body = await callChatGPT(prompt);
   return buildResponse('Science Investigation', body);
 };
 
 export const generateHistoryResource = async ({ period, topic, sourceTypes }) => {
-  const prompt = `Create a history resource pack for the ${period} period on ${topic}. Include source types: ${sourceTypes.join(', ')}.`;
+  const prompt = `Create a history resource pack for the ${period} period on ${topic}.\n\nSummarise key information and include source types: ${sourceTypes.join(', ')}.`;
   const body = await callChatGPT(prompt);
   return buildResponse('History Resource', body);
 };


### PR DESCRIPTION
## Summary
- rewrite system prompts with tone and safety guidance
- expand user prompts with structure, bullet lists and tone notes

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_688bbcc8c3f88320ac166d6847121d90